### PR TITLE
Fix compilation when NOTHREADS=1

### DIFF
--- a/src/modbam2bed.c
+++ b/src/modbam2bed.c
@@ -52,7 +52,7 @@ void *pileup_worker(void *arg) {
 #ifdef NOTHREADS
 void process_region(arguments_t args, const char *chr, int start, int end, char *ref, output_files bed_files) {
     fprintf(stderr, "Processing: %s:%d-%d\n", chr, start, end);
-    set_fsets* files = create_filesets(j.args.bam);
+    set_fsets* files = create_filesets(args.bam);
     if (files == NULL) return;
     plp_data pileup = calculate_pileup(
         args.bam, chr, start, end,

--- a/src/modbam2bed.c
+++ b/src/modbam2bed.c
@@ -55,7 +55,7 @@ void process_region(arguments_t args, const char *chr, int start, int end, char 
     set_fsets* files = create_filesets(args.bam);
     if (files == NULL) return;
     plp_data pileup = calculate_pileup(
-        args.bam, chr, start, end,
+        files, chr, start, end,
         args.read_group, args.tag_name, args.tag_value,
         args.threshold, args.mod_base, args.combine,
         args.hts_maxcnt, args.min_mapQ);


### PR DESCRIPTION
This PR fixes the following compilation error when running `make modbam2bed NOTHREADS=1`:

```
src/modbam2bed.c:55:40: error: use of undeclared identifier 'j'
    set_fsets* files = create_filesets(j.args.bam);
                                       ^
```

because `j` is not defined, and I believe it should just be `args.bam`
