### PR TITLE
Fix segmentation fault when accessing a non-existent chromosome

### DIFF
--- a/modbampy/__init__.py
+++ b/modbampy/__init__.py
@@ -130,11 +130,13 @@ class ModBam:
         read_group, tag_name, tag_value = _tidy_args(
             read_group, tag_name, tag_value)
 
-        data = ffi.gc(
-            libbam.create_bam_iter_data(
+        it = libbam.create_bam_iter_data(
                 self._bam_fset, chrom.encode(), start, end,
-                read_group, tag_name, tag_value, min_mapq),
-            libbam.destroy_bam_iter_data)
+                read_group, tag_name, tag_value, min_mapq)
+        if it == ffi.NULL:
+            return
+
+        data = ffi.gc(it, libbam.destroy_bam_iter_data)
         mod_state = ffi.gc(
             libbam.hts_base_mod_state_alloc(),
             libbam.hts_base_mod_state_free)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -51,3 +51,8 @@ class MotifTest(unittest.TestCase):
             reads = list(bam.reads("ecoli1", 0, 4000000))
         qnames = set(x.query_name for x in reads)
         assert(len(qnames) > 1)
+
+    def test_040_nonexisting_chrom(self):
+        with ModBam(test_bam) as bam:
+            reads = list(bam.reads("ecoli1xx", 0, 4000000))
+        assert(reads == [])


### PR DESCRIPTION
This pull request addresses a segmentation fault that occurs when attempting to access a chromosome that does not exist in the BAM file. The changes ensure that the code gracefully handles the situation by stopping iterator instead of proceeding with a null iterator, which caused the segfault.

Changes:

1. Error Handling in `modbampy/__init__.py`: Introduced a check for a NULL pointer when creating BAM iterator data. If the chromosome is missing, the function now returns early, preventing further operations on a null pointer.
2. Test Case in `test/test_api.py`: Added a new test case `test_040_nonexisting_chrom` to verify the behavior when attempting to read from a non-existent chromosome. The test ensures that an empty list is returned, confirming that no segfault occurs.